### PR TITLE
Add support for animated PNGs

### DIFF
--- a/stego_lsb/LSBSteg.py
+++ b/stego_lsb/LSBSteg.py
@@ -121,7 +121,7 @@ def hide_data(
     image, input_file = prepare_hide(input_image_path, input_file_path)
     image = hide_message_in_image(image, input_file.read(), num_lsb)
     input_file.close()
-    image.save(steg_image_path, compress_level=compression_level)
+    image.save(steg_image_path, compress_level=compression_level, save_all=image.is_animated)
 
 
 def recover_message_from_image(input_image, num_lsb):


### PR DESCRIPTION
Adds (basic) support for working with animated PNGs by setting the value
of `save_all` in the call to `image.save`.